### PR TITLE
Added GridSplitter to query selection window

### DIFF
--- a/QueryDesk/ConnectionTabControl.xaml
+++ b/QueryDesk/ConnectionTabControl.xaml
@@ -5,18 +5,25 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:avalonedit="http://icsharpcode.net/sharpdevelop/avalonedit" x:Class="QueryDesk.ConnectionTabControl" 
              mc:Ignorable="d" Width="739" Height="400">
-    <Grid>
+    <Grid ScrollViewer.VerticalScrollBarVisibility="Disabled">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="42"/>
+            <RowDefinition Height="45"/>
+            <RowDefinition Height="284*"/>
+            <RowDefinition Height="22"/>
+        </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition/>
         </Grid.ColumnDefinitions>
-        <Label Content="Query" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="10,11,0,0" />
-        <ComboBox x:Name="cmbQueries" VerticalAlignment="Top" Margin="72,13,226,0" SelectionChanged="cmbQueries_SelectionChanged"/>
-        <Button x:Name="btnGoQuery" Content="Go" HorizontalAlignment="Right" Margin="0,14,146,0" VerticalAlignment="Top" Width="75" Click="btnGoQuery_Click" ToolTip="Execute query"/>
-        <avalonedit:TextEditor x:Name="edSQL" FontFamily="Consolas" FontSize="12" Margin="10,39,10,0" UseLayoutRounding="False" Text="..." WordWrap="True" Height="23" VerticalAlignment="Top" IsReadOnly="True"/>
-        <DataGrid x:Name="gridQueryResults" HorizontalAlignment="Stretch" Margin="10,67,10,27" CanUserResizeRows="False" IsReadOnly="True" />
-        <Button x:Name="btnEditQuery" Content="Edit" HorizontalAlignment="Right" Margin="0,14,66,0" VerticalAlignment="Top" Width="75" Click="btnEditQuery_Click" ToolTip="Edit query"/>
-        <Button x:Name="btnAddQuery" Content="+" HorizontalAlignment="Right" Height="20" Margin="0,14,38,0" VerticalAlignment="Top" Width="23" Click="btnAddQuery_Click" ToolTip="Add new query"/>
-        <Button x:Name="btnDelQuery" Content="-" HorizontalAlignment="Right" Height="20" Margin="0,14,10,0" VerticalAlignment="Top" Width="23" ToolTip="Remove query" Click="btnDelQuery_Click"/>
-        <StatusBar x:Name="barQuery" HorizontalAlignment="Stretch" Height="22" VerticalAlignment="Bottom" Background="{x:Null}"/>
+        <Label Content="Query" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="10,8,0,0" Width="42" Height="26" />
+        <ComboBox x:Name="cmbQueries" VerticalAlignment="Top" Margin="72,10,226,0" SelectionChanged="cmbQueries_SelectionChanged" Height="22"/>
+        <Button x:Name="btnGoQuery" Content="Go" HorizontalAlignment="Right" Margin="0,10,146,0" VerticalAlignment="Top" Width="75" Click="btnGoQuery_Click" ToolTip="Execute query" Height="22"/>
+        <avalonedit:TextEditor x:Name="edSQL" FontFamily="Consolas" FontSize="12" Margin="10,0" UseLayoutRounding="False" Text="..." WordWrap="True" IsReadOnly="True" Grid.Row="1"/>
+        <DataGrid x:Name="gridQueryResults" HorizontalAlignment="Stretch" Margin="10,9,10,0" CanUserResizeRows="False" IsReadOnly="True" Grid.Row="2" />
+        <Button x:Name="btnEditQuery" Content="Edit" HorizontalAlignment="Right" Margin="0,10,66,0" VerticalAlignment="Top" Width="75" Click="btnEditQuery_Click" ToolTip="Edit query" Height="22"/>
+        <Button x:Name="btnAddQuery" Content="+" HorizontalAlignment="Right" Margin="0,10,38,0" VerticalAlignment="Top" Width="23" Click="btnAddQuery_Click" ToolTip="Add new query" Height="22"/>
+        <Button x:Name="btnDelQuery" Content="-" HorizontalAlignment="Right" Margin="0,10,10,0" VerticalAlignment="Top" Width="23" ToolTip="Remove query" Click="btnDelQuery_Click" Height="22"/>
+        <StatusBar x:Name="barQuery" HorizontalAlignment="Stretch" Height="22" VerticalAlignment="Bottom" Background="{x:Null}" Grid.Row="3"/>
+        <GridSplitter HorizontalAlignment="Stretch" Height="9" ResizeDirection="Rows" RenderTransformOrigin="0.5,0.5" VerticalAlignment="Top" Grid.Row="2" Margin="10,0"/>
     </Grid>
 </UserControl>


### PR DESCRIPTION
This adds a `GridSplitter` to the query selection window so that the selected query editor can be expanded at any time.

Closes #46.
